### PR TITLE
Wrap log messages content

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="styles/main.css">
 </head>
 <body ng-app="webapp">
-  <div class="container" ng-view></div>
+  <div class="container-fluid" ng-view></div>
 
   <script src="vendors/jquery.min.js"></script>
   <script src="vendors/angular.min.js"></script>

--- a/webapp/scripts/controllers.js
+++ b/webapp/scripts/controllers.js
@@ -14,6 +14,8 @@ angular.module('webapp').controller('MainCtrl', function ($scope, $http) {
   $scope.pages = 1;
   $scope.pageToGoto = 0;
 
+  $scope.wrapText = false;
+
   $scope.spinner = 'false';
 
   $scope.logs = [];
@@ -49,6 +51,10 @@ angular.module('webapp').controller('MainCtrl', function ($scope, $http) {
       $scope.page++;
       search();
     }
+  };
+
+  $scope.wrapLogMessages = function (wrapText) {
+    $scope.wrapText = wrapText;
   };
 
   function search() {

--- a/webapp/styles/main.css
+++ b/webapp/styles/main.css
@@ -18,6 +18,14 @@ body {
     width: 150px;
 }
 
+.log-table-messages-content {  /* http://stackoverflow.com/a/248013/5649751 */
+  white-space: pre-wrap;       /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+}
+
 #spinner {
     margin-top: 50px;
     margin-bottom: 50px;

--- a/webapp/views/main.html
+++ b/webapp/views/main.html
@@ -108,6 +108,13 @@
         <div class="form-group">
           <input type="text" id="quickfilter" class="form-control" placeholder="Quick filter" ng-model="quickfilter.$">
         </div>
+
+        <button class="pull-right btn" ng-if="wrapText" ng-click="wrapLogMessages(false)">
+          Unwrap text
+        </button>
+        <button class="pull-right btn btn-primary" ng-if="!wrapText" ng-click="wrapLogMessages(true)">
+          Wrap text
+        </button>
       </form><br>
       <table class="table table-bordered table-hover">
         <thead>
@@ -135,7 +142,7 @@
           <td>{{ log.namespace }}</td>
           <td>{{ log.level }}</td>
           <td>{{ log.date | prettydate }}</td>
-          <td><pre>{{ log.messages | json }}</pre></td>
+          <td><pre ng-class="{ 'log-table-messages-content': wrapText }">{{ log.messages | json }}</pre></td>
         </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Sometimes the log messages are very long : you need to scroll horizontally to see the full message.

The solution here is to provide a new button that toggle the word wrapping in `<pre></pre>` tags found in the log messages column.

Additionally, the main layout is modified to fit the screen:
- it shows more informations
- the content is centered

![h-mongo-wrap](https://cloud.githubusercontent.com/assets/5774198/17324655/dc5c181c-58a7-11e6-87ab-e5b0a931679b.gif)
